### PR TITLE
Check if disk is already present before importing and resizing

### DIFF
--- a/tasks/5_create_disks.yaml
+++ b/tasks/5_create_disks.yaml
@@ -1,21 +1,31 @@
 ---
-- name: Import the cloned image disk
+- name: Get details about the primary disk
   delegate_to: "{{ vm_node_ip }}"
-  ansible.builtin.shell:
-    cmd: "qm importdisk {{ vm_id }} /var/lib/vz/template/iso/{{ vm_img_filename }} local-lvm"
+  shell:
+    cmd: "qm config {{ vm_id }} | awk '/^scsi0:/ {print $2}'"
+  register: vm_primary_disk
+  ignore_errors: true
 
-- name: Attach the cloned disk.
-  delegate_to: "{{ vm_node_ip }}"
-  ansible.builtin.shell:
-    cmd: "qm set {{ vm_id }} --scsi0 local-lvm:vm-{{ vm_id }}-disk-0"
+- name: Import, attach and resize disk if necessary
+  block:
+    - name: Import the cloned image disk
+      delegate_to: "{{ vm_node_ip }}"
+      ansible.builtin.shell:
+        cmd: "qm importdisk {{ vm_id }} /var/lib/vz/template/iso/{{ vm_img_filename }} local-lvm"
 
-- name: Grow existing disk
-  delegate_to: localhost
-  community.general.proxmox_disk:
-    api_host: "{{ vm_node_ip }}"
-    api_user: "{{ vm_node_api_user }}"
-    api_password: "{{ vm_node_api_password }}"
-    vmid: "{{ vm_id }}"
-    disk: scsi0
-    size: "{{ vm_disk_size }}G"
-    state: resized
+    - name: Attach the cloned disk.
+      delegate_to: "{{ vm_node_ip }}"
+      ansible.builtin.shell:
+        cmd: "qm set {{ vm_id }} --scsi0 local-lvm:vm-{{ vm_id }}-disk-0"
+
+    - name: Grow existing disk
+      delegate_to: localhost
+      community.general.proxmox_disk:
+        api_host: "{{ vm_node_ip }}"
+        api_user: "{{ vm_node_api_user }}"
+        api_password: "{{ vm_node_api_password }}"
+        vmid: "{{ vm_id }}"
+        disk: scsi0
+        size: "{{ vm_disk_size }}G"
+        state: resized
+  when: "(vm_primary_disk.failed) or ('local-lvm:vm-' ~ vm_id ~ '-disk-0,size=' ~ vm_disk_size ~ 'G' not in vm_primary_disk.stdout)"


### PR DESCRIPTION
Perhaps you have a more elegant solution (I'm new to Ansible), but I was facing an issue where if you ran a playbook with this role more than once it would keep importing, resizing and associating the same base image with the vm.
![image](https://github.com/RasmusGodske/ansible-role-proxmox-provisioner/assets/673092/440a41da-0941-4841-900e-036cf5f6125b)
